### PR TITLE
Fix label misalignment when scaling world

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,9 @@ function layout(){
     (w - CONFIG.WORLD_SIZE * scale)/2,
     (h - CONFIG.WORLD_SIZE * scale)/2
   );
-  labelsLayer.scale.set(1/scale);
+  labelsLayer.children.forEach(label => {
+    label.scale.set(1/scale);
+  });
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- ensure labels follow world scaling by inversely scaling each label text instead of the whole layer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c48e7cd91883248c02ea023767566f